### PR TITLE
Easy switching wifi/monitor device

### DIFF
--- a/builder/data/usr/bin/bettercap-launcher
+++ b/builder/data/usr/bin/bettercap-launcher
@@ -18,11 +18,10 @@ if ! check_brcm; then
   sleep 10
 fi
 
-# start mon0
 start_monitor_interface
 
 if is_auto_mode_no_delete; then
-  /usr/local/bin/bettercap -no-colors -caplet pwnagotchi-auto -iface mon0
+  /usr/local/bin/bettercap -no-colors -caplet pwnagotchi-auto -iface ${PWNY_MON_IFACE}
 else
-  /usr/local/bin/bettercap -no-colors -caplet pwnagotchi-manual -iface mon0
+  /usr/local/bin/bettercap -no-colors -caplet pwnagotchi-manual -iface ${PWNY_MON_IFACE}
 fi

--- a/builder/data/usr/bin/fix_pwny_iface.sh
+++ b/builder/data/usr/bin/fix_pwny_iface.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/bash -e
+#
+# Set up monitor device in config file and pwnlib
+#
+# If you want to use a device other than the default,
+# specify its "phy" number.  You can find that by running
+# this command in a shell:
+#
+#    /sbin/iw dev
+#
+# Look for the device you want, and find the "phy#" header
+# Then pass that number to this program. For example, if your
+# device shows up as phy#2, you would run:
+#
+#  fix_pwny_iface.sh 2
+#
+
+
+phy=${1:-0}
+
+mondev=$(/sbin/iw dev | grep -B 7 -A 7 "type monitor" | grep -A 7 phy\# | grep Interface | cut  -d ' ' -f2)
+if [ "$mondev" ]; then
+    echo "Stopping pwnagotchi services"
+    systemctl stop pwnagotchi bettercap pwngrid-peer
+
+    airmon-ng stop $mondev
+fi
+
+# locate the wifi device that becomes the monitor device
+wifidev=$(/sbin/iw dev | grep -A 7 phy\#$phy | grep Interface | cut  -d ' ' -f2 | head)
+
+if [ "$wifidev" ]; then
+    echo "Found wifi device '$wifidev'"
+else
+    echo "No device found for phy#$phy"
+    exit
+fi
+
+airmon-ng start $wifidev
+
+# locate the monitor mode device
+mondev=$(/sbin/iw dev | grep -B 7 -A 7 "type monitor" | grep -A 7 phy\#$phy | grep Interface | cut  -d ' ' -f2)
+
+if [ "$mondev" ]; then
+    echo "Found monitor device $mondev"
+    airmon-ng stop $mondev
+else
+    echo "No device found for phy#$phy"
+    exit
+fi
+
+for conf in /etc/pwnagotchi/config.toml; do
+
+    if grep -q main.iface $conf ; then
+	defdev=$(grep iface $conf | cut -d \" -f 2)
+	if [ "$mondev" != "$defdev" ]; then
+	    echo "Config says $defdev, but the device says $mondev"
+
+	    # my bananapi device has same name in monitor mode as not
+
+	    sed -i.bak -e "s/^main.iface = \"$defdev\"/main.iface = \"$mondev\"/" $conf
+	else
+	    echo "$conf already set for $mondev"
+	fi
+    else
+	echo "adding interface to $conf"
+        echo "main.iface = \"$mondev\"" >>$conf
+    fi
+done
+
+# set WIFI device in pwnlib
+echo updating pwnlib for phy$phy
+sudo sed -i.bak -e "s/^#*PWNY_EXT_WLAN=\".*\"/PWNY_EXT_WLAN=\"$wifidev\"/" /usr/bin/pwnlib
+

--- a/builder/data/usr/bin/pwngrid-launcher
+++ b/builder/data/usr/bin/pwngrid-launcher
@@ -1,5 +1,13 @@
 #!/usr/bin/bash
 
 source /usr/bin/pwnlib
+LOG="-log /home/pi/log/pwngrid-peer.log"
 
-/usr/local/bin/pwngrid -keys /etc/pwnagotchi -address 127.0.0.1:8666 -client-token /root/.api-enrollment.json -wait -log /var/log/pwngrid-peer.log -iface mon0
+# check to see if pwnagotchi is advertising and disable if not
+# some wifi drivers to not support advertising. Disable in /etc/pwnagotchi/config.toml
+
+if egrep "personality.advertise.*=.*false" /etc/pwnagotchi/config.toml ; then
+  ADVERTISE="-advertise=false"
+fi
+
+echo /usr/local/bin/pwngrid -keys /etc/pwnagotchi -address 127.0.0.1:8666 -client-token /root/.api-enrollment.json -wait ${LOG} -iface ${PWNY_MON_IFACE} ${ADVERTISE}

--- a/builder/data/usr/bin/pwnlib
+++ b/builder/data/usr/bin/pwnlib
@@ -1,8 +1,38 @@
 #!/usr/bin/env bash
 
+# If you want to use an external wifi device, set it in PWNY_EXT_WLAN
+# Then put the monitor mode inteface name into /etc/pwnagotchi/config.toml
+# as  "main.iface".
+#
+PWNY_EXT_WLAN="wlan0"
+
+# OG defaults
+export PWNY_WIFI_IFACE='wlan0'
+export PWNY_MON_IFACE='mon0'
+
+# look for monitor interface in config files
+for conf in /usr/local/lib/python3.9/dist-packages/pwnagotchi/defaults.toml \
+		/etc/pwnagotchi/config.toml; do
+    if grep -q main.iface $conf; then
+	mondev=$(grep main.iface $conf | cut -d \" -f2)
+	export PWNY_MON_IFACE=$mondev
+    fi
+done
+
+if [ "$PWNY_EXT_WLAN" != "" ]; then
+    export PWNY_WIFI_IFACE=$PWNY_EXT_WLAN
+else
+    # choose phy0 wifi device (typically built in)
+    wifidev=$(/sbin/iw dev | grep -A 7 phy\#0 | grep Interface | cut  -d ' ' -f2)
+    export PWNY_WIFI_IFACE=$wifidev
+fi
+
+
 # preload the v1.9 libpcap for injection packets that seem to be broken in 1.10
-export LD_PRELOAD=/usr/local/lib/libpcap.so.1
-export LD_LIBRARY_PATH=/usr/local/lib
+if [ -f /usr/local/lib/libpcap.so.1 ]; then
+  export LD_PRELOAD=/usr/local/lib/libpcap.so.1
+  export LD_LIBRARY_PATH=/usr/local/lib
+fi
 
 # well ... it blinks the led
 blink_led() {
@@ -34,26 +64,20 @@ reload_brcm() {
     return 1
   fi
   sleep 2
-  iw dev wlan0 set power_save off
+  iw dev ${PWNY_WIFI_IFACE} set power_save off
   return 0
 }
 
-# starts mon0
+# starts ${PWNY_MON_IFACE}
 start_monitor_interface() {
   rfkill unblock all
-  ifconfig wlan0 up
-  sleep 3
-  iw dev wlan0 set power_save off
-  iw phy "$(iw phy | head -1 | cut -d" " -f2)" interface add mon0 type monitor
-  sleep 2
-  rfkill unblock all
-  ifconfig wlan0 down
-  ifconfig mon0 up
+  ifconfig ${PWNY_WIFI_IFACE} up
+  airmon-ng start ${PWNY_WIFI_IFACE}
 }
 
-# stops mon0
+# stops ${PWNY_MON_IFACE}
 stop_monitor_interface() {
-  ifconfig mon0 down && iw dev mon0 del
+  airmon-ng stop ${PWNY_MON_IFACE}
 }
 
 # returns 0 if the specificed network interface is up
@@ -151,8 +175,8 @@ is_decrypted() {
         fi
       fi
 
-      if ! ip -4 addr show wlan0 | grep inet >/dev/null 2>&1; then
-        >/dev/null 2>&1 ip addr add 192.168.0.10/24 dev wlan0
+      if ! ip -4 addr show ${PWNY_WIFI_IFACE} | grep inet >/dev/null 2>&1; then
+        >/dev/null 2>&1 ip addr add 192.168.0.10/24 dev ${PWNY_WIFI_IFACE}
       fi
 
       if ! pgrep -f decryption-webserver >/dev/null 2>&1; then
@@ -173,11 +197,11 @@ network={
     frequency=2437
 }
 EOF
-        >/dev/null 2>&1 wpa_supplicant -u -s -O -D nl80211 -i wlan0 -c /tmp/wpa_supplicant.conf &
+        >/dev/null 2>&1 wpa_supplicant -u -s -O -D nl80211 -i ${PWNY_WIFI_IFACE} -c /tmp/wpa_supplicant.conf &
       fi
 
       if ! pgrep dnsmasq >/dev/null 2>&1; then
-        >/dev/null 2>&1 dnsmasq -k -p 53 -h -O "6,192.168.0.10" -A "/#/192.168.0.10" -i wlan0 -K -F 192.168.0.50,192.168.0.60,255.255.255.0,24h &
+        >/dev/null 2>&1 dnsmasq -k -p 53 -h -O "6,192.168.0.10" -A "/#/192.168.0.10" -i ${PWNY_WIFI_IFACE} -K -F 192.168.0.50,192.168.0.60,255.255.255.0,24h &
       fi
 
       return 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed pwnlib to pull the monitor mode interface name from /etc/pwnagotchi/config.toml (or default.toml if not in config.toml). Changed pwngrid and bettercap launchers to use a variable from pwnlib for monitor device instead of hard coded.  fix_pwny_iface.sh edits config.toml and pwnlib to set the devices based on interface "phy#" number.  This makes it easy to switch pwnagotchi to a USB wifi dongle, and easily switch back to internal wifi.

## Description
<!--- Describe your changes in detail -->
Same as above

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

Instead of having to edit several files to switch wifi devices, you can just run "fix_pwny_iface.sh #" with the "phy" number for the interface.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was first developed for bananapi m4zero, where the internal wifi does not show up as "wlan0", but as a uniquely named device (maybe a serial number. Since it was having to identify devices, I made the fix_pwny_iface script take a parameter so you could pick the device index instead of just the default device.  Tested with a USB dongle on the bananapi, and switched pwnagotchi back and forth between the two interfaces.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
