### PR TITLE
Thread id prctl

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging
 import time
 import re
-
+import prctl
 
 
 from pwnagotchi._version import __version__
@@ -112,6 +112,7 @@ def temperature(celsius=True):
 
 def shutdown():
     logging.warning("shutting down ...")
+    prctl.set_name("pwny shutdown")
 
     from pwnagotchi.ui import view
     if view.ROOT:
@@ -130,6 +131,7 @@ def shutdown():
 
 
 def restart(mode):
+    prctl.set_name("pwny restart %s" % mode)
     logging.warning("restarting in %s mode ...", mode)
 
     if mode == 'AUTO':
@@ -142,6 +144,7 @@ def restart(mode):
 
 
 def reboot(mode=None):
+    prctl.set_name("pwny reboot %s" % repr(mode))
     if mode is not None:
         mode = mode.upper()
         logging.warning("rebooting in %s mode ...", mode)

--- a/pwnagotchi/fs/__init__.py
+++ b/pwnagotchi/fs/__init__.py
@@ -5,6 +5,7 @@ import contextlib
 import shutil
 import _thread
 import logging
+import prctl
 
 from time import sleep
 from distutils.dir_util import copy_tree
@@ -145,6 +146,7 @@ class MemoryFS:
 
     def daemonize(self, interval=60):
         logging.debug("[FS] Daemonized...")
+        prctl.set_name("[FS] daemon")
         while True:
             self.sync()
             sleep(interval)

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -124,7 +124,7 @@ class BTNap:
             device = ifaces.get(BTNap.IFACE_DEV)
             if device is None:
                 continue
-            if str(device['Address']).lower() == device_address.lower() and path.startswith(path_prefix):
+            if str(device['Address']).lower().strip() == device_address.lower().strip() and path.startswith(path_prefix):
                 obj = bus.get_object(BTNap.IFACE_BASE, path)
                 return dbus.Interface(obj, BTNap.IFACE_DEV)
         raise BTError('Bluetooth device not found')

--- a/pwnagotchi/plugins/default/led.py
+++ b/pwnagotchi/plugins/default/led.py
@@ -2,6 +2,7 @@ from threading import Event
 import _thread
 import logging
 import time
+import prctl
 
 import pwnagotchi.plugins as plugins
 
@@ -67,6 +68,7 @@ class Led(plugins.Plugin):
         self._led(0)
 
     def _worker(self):
+        prctl.set_name("led worker")
         while True:
             self._event.wait()
             self._event.clear()

--- a/pwnagotchi/plugins/default/session-stats.py
+++ b/pwnagotchi/plugins/default/session-stats.py
@@ -7,6 +7,7 @@ from pwnagotchi import plugins
 from pwnagotchi.utils import StatusFile
 from flask import render_template_string
 from flask import jsonify
+import prctl
 
 TEMPLATE = """
 {% extends "base.html" %}
@@ -165,6 +166,7 @@ class GhettoClock:
         self._counter_thread.start()
 
     def counter(self):
+        prctl.set_name("SessStatClock")
         while True:
             with self.lock:
                 self._track += timedelta(seconds=1)

--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import threading
+import prctl
 
 import pwnagotchi.plugins as plugins
 import pwnagotchi.ui.hw as hw
@@ -106,6 +107,7 @@ class Display(View):
         return img
 
     def _render_thread(self):
+        prctl.set_name("UI Render")
         """Used for non-blocking screen updating."""
 
         while True:

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -2,6 +2,8 @@ import _thread
 import logging
 import random
 import time
+import prctl
+
 from threading import Lock
 
 from PIL import ImageDraw
@@ -128,6 +130,11 @@ class View(object):
             self._render_cbs.append(cb)
 
     def _refresh_handler(self):
+        try:
+            prctl.set_name("ui refresh")
+        except Exeception as e:
+            logging.exception(repr(e))
+
         delay = 1.0 / self._config['ui']['fps']
         while True:
             try:

--- a/pwnagotchi/ui/web/handler.py
+++ b/pwnagotchi/ui/web/handler.py
@@ -4,6 +4,8 @@ import base64
 import _thread
 import secrets
 import json
+import prctl
+
 from functools import wraps
 
 # https://stackoverflow.com/questions/14888799/disable-console-messages-in-flask-server

--- a/pwnagotchi/ui/web/server.py
+++ b/pwnagotchi/ui/web/server.py
@@ -2,6 +2,7 @@ import _thread
 import secrets
 import logging
 import os
+import prctl
 
 # https://stackoverflow.com/questions/14888799/disable-console-messages-in-flask-server
 logging.getLogger('werkzeug').setLevel(logging.ERROR)
@@ -28,6 +29,8 @@ class Server:
             _thread.start_new_thread(self._http_serve, ())
 
     def _http_serve(self):
+        prctl.set_name("pwny http")
+
         if self._address is not None:
             web_path = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Mostly added 'prctl' calls to set the name of the process threads. This allows each thread to show as what it is instead of just "pwnagotchi". Identify which threads/plugins are using excess CPU, etc.