### PR TITLE
Fix bettercap websocket thread stopping after first disconnect

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -462,12 +462,10 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         while True:
             logging.debug("[agent:_event_poller] polling events ...")
             try:
-                loop.create_task(self.start_websocket(self._on_event))
-                loop.run_forever()
-
-                logging.warn("[agent:_event_poller] loop loop loop")
+                loop.run_until_complete(self.start_websocket(self._on_event))
+                logging.warning("[agent:_event_poller] start_websocket returned, restarting")
             except Exception as ex:
-                logging.error("[agent:_event_poller] Error while polling via websocket (%s)", ex)
+                logging.error("[agent:_event_poller] error while polling via websocket (%s), restarting", ex)
 
     def start_event_polling(self):
         # start a thread and pass in the mainloop

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -42,16 +42,13 @@ class Client(object):
         return decode(r)
 
     async def start_websocket(self, consumer):
-      try:
         s = "%s/events" % self.websocket
         restart_monitor = False
-        #while True:
-        if True:
+        while True:
             try:
-
-                async with websockets.connect(s, timeout = 10, ping_interval=60, ping_timeout=90) as ws:
+                async with websockets.connect(s, timeout=10, ping_interval=60, ping_timeout=90) as ws:
                     if restart_monitor:
-                        logging.info("resetting bettercap is so fetch")
+                        logging.info("bettercap reconnected, resetting wifi settings")
                         self._reset_wifi_settings()
                         if self.mode != 'manual':
                             self.run('wifi.recon on')
@@ -61,19 +58,18 @@ class Client(object):
                         try:
                             await consumer(msg)
                         except Exception as ex:
-                            logging.error("Error while parsing event (%s)", ex)
+                            logging.error("error while parsing bettercap event (%s)", ex)
             except asyncio.TimeoutError:
-                logging.error("Connection timed out. Reconnecting %s" % (e))
-#            except websockets.ConnectionClosedError:
-#                logging.error("Lost websocket connection. Reconnecting...")
-#            except websockets.WebSocketException as wex:
-#                logging.error("Websocket exception (%s)" % wex)
+                logging.error("bettercap websocket timed out, reconnecting...")
+            except websockets.exceptions.ConnectionClosedError as e:
+                logging.error("bettercap websocket connection closed (%s), reconnecting...", e)
+            except websockets.exceptions.WebSocketException as e:
+                logging.error("bettercap websocket exception (%s), reconnecting...", e)
             except Exception as e:
-                logging.exception("WEBSOCKET RETURN: %s" % (e))
-                
+                logging.exception("bettercap websocket error (%s), reconnecting...", e)
+
             restart_monitor = True
-      except Exception as e:
-        logging.exception("bye webhook: %s" % e)
+            await asyncio.sleep(5)
 
     def run(self, command, verbose_errors=True):
         r = requests.post("%s/session" % self.url, auth=self.auth, json={'cmd': command})


### PR DESCRIPTION
Four bugs caused the bettercap monitor thread to silently die:

1. bettercap.py: `while True:` was commented out and replaced with `if True:`, so the websocket was never reconnected after closing.

2. bettercap.py: `asyncio.TimeoutError` handler referenced undefined variable `e`, raising NameError and exiting the coroutine.

3. bettercap.py: `ConnectionClosedError` and `WebSocketException` handlers were commented out; those exceptions fell through to the generic handler and exited instead of reconnecting.

4. agent.py: `loop.create_task()` + `loop.run_forever()` meant that once the (now-dead) task completed, run_forever() blocked forever and the outer while-True restart loop could never iterate. Replaced with `loop.run_until_complete()` so the outer loop can restart if start_websocket ever exits.

Also adds a 5-second sleep between reconnect attempts to avoid hammering bettercap during repeated failures.

